### PR TITLE
feat: Develop News Microservice and fix monolith news page

### DIFF
--- a/client/src/pages/NewsPage.tsx
+++ b/client/src/pages/NewsPage.tsx
@@ -3,9 +3,9 @@ import Layout from '../components/Layout';
 
 // Interfaces for data structures (can be moved to a common types file)
 interface NewsItem {
-  id: number;
+  id: string; // Changed from number to string to match backend DTO
   title: string;
-  date: string;
+  date: string; // Backend sends ISO string, which is fine
   category?: string;
   image?: string;
   excerpt?: string; // Added for news card
@@ -48,7 +48,7 @@ const NewsPage: React.FC = () => {
   useEffect(() => {
     const fetchNewsPageData = async () => {
       try {
-        const response = await fetch('/api/news-page-data'); // Updated API endpoint
+        const response = await fetch('/api/news/page-data'); // Corrected API endpoint
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }

--- a/client/src/pages/NewsPage.tsx
+++ b/client/src/pages/NewsPage.tsx
@@ -22,13 +22,13 @@ interface HotTool {
 
 // Placeholder data - to be replaced with API calls
 const placeholderNews: NewsItem[] = [
-  { id: 1, title: 'AI News Title 1', date: '2024-06-05', category: 'AI头条', image: 'https://via.placeholder.com/200x150', excerpt: 'This is a sample excerpt for the news item, showcasing the latest developments.', views: '1.2K', likes: 56 },
-  { id: 2, title: 'Another AI Breakthrough', date: '2024-06-04', category: '技术进展', image: 'https://via.placeholder.com/200x150', excerpt: 'Details about a significant advancement in AI technology and its potential impact.', views: '2.5K', likes: 120 },
+  { id: '1', title: 'AI News Title 1', date: '2024-06-05', category: 'AI头条', image: 'https://via.placeholder.com/200x150', excerpt: 'This is a sample excerpt for the news item, showcasing the latest developments.', views: '1.2K', likes: 56 },
+  { id: '2', title: 'Another AI Breakthrough', date: '2024-06-04', category: '技术进展', image: 'https://via.placeholder.com/200x150', excerpt: 'Details about a significant advancement in AI technology and its potential impact.', views: '2.5K', likes: 120 },
 ];
 
 const placeholderRecommendedTools: HotTool[] = [
-    { id: 1, name: 'ChatGPT', description: '智能对话助手', icon: 'https://ext.same-assets.com/155488376/946268843.jpeg'},
-    { id: 2, name: 'Claude 4', description: '高级AI助手', icon: 'https://ext.same-assets.com/155488376/614836080.jpeg'},
+    { id: 1, name: 'ChatGPT', description: '智能对话助手', icon: 'https://ext.same-assets.com/155488376/946268843.jpeg'}, // These IDs can remain numbers if HotTool interface uses number
+    { id: 2, name: 'Claude 4', description: '高级AI助手', icon: 'https://ext.same-assets.com/155488376/614836080.jpeg'}, // These IDs can remain numbers if HotTool interface uses number
 ];
 
 const NewsPage: React.FC = () => {

--- a/news-microservice/.eslintrc.js
+++ b/news-microservice/.eslintrc.js
@@ -1,0 +1,25 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint/eslint-plugin'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ['.eslintrc.js'],
+  rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
+};

--- a/news-microservice/nest-cli.json
+++ b/news-microservice/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/news-microservice/package.json
+++ b/news-microservice/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "news-microservice",
+  "version": "0.0.1",
+  "description": "News Microservice",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/mongoose": "^10.0.0",
+    "mongoose": "^7.0.0",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.0.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.3.1",
+    "eslint": "^8.42.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "prettier": "^3.0.0",
+    "ts-loader": "^9.4.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.3"
+  }
+}

--- a/news-microservice/src/app.controller.ts
+++ b/news-microservice/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get('health')
+  getHealth(): string {
+    return this.appService.getHealth();
+  }
+}

--- a/news-microservice/src/app.module.ts
+++ b/news-microservice/src/app.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { NewsModule } from './news/news.module';
+import { databaseConfig } from './config/database.config'; // Import database config
+
+@Module({
+  imports: [
+    MongooseModule.forRoot(databaseConfig.uri), // Configure Mongoose
+    NewsModule, // Import the NewsModule
+  ],
+  controllers: [AppController], // AppController for health check
+  providers: [AppService],
+})
+export class AppModule {}

--- a/news-microservice/src/app.service.ts
+++ b/news-microservice/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHealth(): string {
+    return 'News Microservice is healthy!';
+  }
+}

--- a/news-microservice/src/config/database.config.ts
+++ b/news-microservice/src/config/database.config.ts
@@ -1,0 +1,5 @@
+// Basic database configuration
+// In a real app, this would come from environment variables or a more robust config system.
+export const databaseConfig = {
+  uri: process.env.NEWS_MONGO_URI || 'mongodb://localhost:27017/news_microservice_db',
+};

--- a/news-microservice/src/main.ts
+++ b/news-microservice/src/main.ts
@@ -1,0 +1,11 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { Logger } from '@nestjs/common';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const port = process.env.PORT || 3001; // Default port for the microservice
+  await app.listen(port);
+  Logger.log(`🚀 News Microservice running on port ${port}`, 'Bootstrap');
+}
+bootstrap();

--- a/news-microservice/src/news/dto/news.dto.ts
+++ b/news-microservice/src/news/dto/news.dto.ts
@@ -1,0 +1,37 @@
+import { NewsEntity } from '../entities/news.entity'; // Adjust path as entity will be local
+
+// DTO for creating news
+export class CreateNewsDto {
+    title: string;
+    excerpt: string;
+    content: string;
+    category: string;
+    publishedAt: Date;
+    imageUrl?: string;
+    tags?: string[];
+    author?: string;
+    sourceUrl?: string;
+    isFeatured?: boolean;
+    views?: number;
+}
+
+// DTO for updating news
+export class UpdateNewsDto extends CreateNewsDto {}
+
+// DTO for individual news items tailored for NewsPage.tsx
+export class NewsItemDto {
+  id: string; // MongoDB IDs are strings
+  title: string;
+  date: string; // Will be formatted string from Date
+  category?: string;
+  image?: string;
+  excerpt?: string;
+  views?: number;
+}
+
+// DTO for the /api/news-page-data endpoint response
+export class NewsPageDataDto {
+  newsItems: NewsItemDto[];
+  recommendedTools: { id: number; name: string; description: string; icon: string; }[];
+  popularTopics: { id: string; name: string; }[];
+}

--- a/news-microservice/src/news/entities/news.entity.ts
+++ b/news-microservice/src/news/entities/news.entity.ts
@@ -1,0 +1,22 @@
+import { Document } from 'mongoose';
+
+export interface NewsEntity extends Document {
+  // _id is implicitly part of Document, often accessed via id virtual
+  title: string;
+  excerpt: string;
+  content: string;
+  imageUrl?: string;
+
+  category: string;
+  tags?: string[];
+
+  author?: string;
+  sourceUrl?: string;
+
+  publishedAt: Date;
+
+  isFeatured?: boolean;
+
+  views?: number;
+  // likes?: number; // Not currently in schema
+}

--- a/news-microservice/src/news/news.controller.ts
+++ b/news-microservice/src/news/news.controller.ts
@@ -1,0 +1,92 @@
+import { Controller, Get, Post, Body, Param, Put, Delete, Query, NotFoundException, ParseIntPipe, DefaultValuePipe } from '@nestjs/common';
+import { NewsService } from './news.service';
+import { NewsEntity } from './entities/news.entity';
+import { CreateNewsDto, UpdateNewsDto, NewsPageDataDto, NewsItemDto } from './dto/news.dto';
+
+@Controller() // Define routes at the root of the microservice
+export class NewsController {
+  constructor(private readonly newsService: NewsService) {}
+
+  private mapNewsEntityToDto(entity: NewsEntity): NewsItemDto {
+    return {
+      id: entity.id || entity._id.toString(),
+      title: entity.title,
+      date: entity.publishedAt.toISOString(),
+      category: entity.category,
+      image: entity.imageUrl,
+      excerpt: entity.excerpt,
+      views: entity.views,
+    };
+  }
+
+  @Get('page-data')
+  async getNewsPageData(
+    // Potentially add query params for pagination/filtering for newsItems on this page
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page?: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit?: number,
+    @Query('category') category?: string,
+    @Query('isFeatured') isFeatured?: string,
+  ): Promise<NewsPageDataDto> {
+    const isFeaturedBool = isFeatured === undefined ? undefined : isFeatured === 'true';
+    const newsServiceResponse = await this.newsService.findAll(category, isFeaturedBool, page, limit);
+
+    const newsItems = newsServiceResponse.data.map(entity => this.mapNewsEntityToDto(entity));
+
+    // Placeholder data for recommendedTools and popularTopics (as in monolith)
+    const recommendedTools = [
+      { id: 1, name: 'ChatGPT', description: '智能对话助手', icon: 'https://ext.same-assets.com/155488376/946268843.jpeg'},
+      { id: 2, name: 'Claude 4', description: '高级AI助手', icon: 'https://ext.same-assets.com/155488376/614836080.jpeg'},
+    ];
+    const popularTopics = [
+      { id: 'ai-ethics', name: 'AI Ethics' },
+      { id: 'generative-ai', name: 'Generative AI' },
+      { id: 'llms', name: 'Large Language Models' },
+    ];
+
+    return {
+      newsItems, // Consider adding pagination info for newsItems if needed directly on page-data
+      recommendedTools,
+      popularTopics,
+    };
+  }
+
+  @Post('articles')
+  async create(@Body() createNewsDto: CreateNewsDto): Promise<NewsItemDto> {
+    const newsEntity = await this.newsService.create(createNewsDto);
+    return this.mapNewsEntityToDto(newsEntity);
+  }
+
+  @Get('articles')
+  async findAll(
+    @Query('category') category?: string,
+    @Query('isFeatured') isFeatured?: string, // 'true' or 'false'
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page?: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit?: number,
+  ): Promise<{ data: NewsItemDto[], total: number, page: number, limit: number }> {
+    const isFeaturedBool = isFeatured === undefined ? undefined : isFeatured === 'true';
+    const { data: entities, total, page: p, limit: l } = await this.newsService.findAll(category, isFeaturedBool, page, limit);
+    const newsItemDtos = entities.map(entity => this.mapNewsEntityToDto(entity));
+    return { data: newsItemDtos, total, page:p, limit:l };
+  }
+
+  @Get('articles/:id')
+  async findOne(@Param('id') id: string): Promise<NewsItemDto> {
+    const newsEntity = await this.newsService.findOne(id);
+    if (!newsEntity) {
+      throw new NotFoundException(`News with ID ${id} not found`);
+    }
+    return this.mapNewsEntityToDto(newsEntity);
+  }
+
+  @Put('articles/:id')
+  async update(@Param('id') id: string, @Body() updateNewsDto: UpdateNewsDto): Promise<NewsItemDto> {
+    const updatedEntity = await this.newsService.update(id, updateNewsDto);
+    return this.mapNewsEntityToDto(updatedEntity);
+  }
+
+  @Delete('articles/:id')
+  async remove(@Param('id') id: string): Promise<NewsItemDto> {
+    const deletedEntity = await this.newsService.remove(id);
+    return this.mapNewsEntityToDto(deletedEntity);
+  }
+}

--- a/news-microservice/src/news/news.module.ts
+++ b/news-microservice/src/news/news.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { NewsController } from './news.controller';
+import { NewsService } from './news.service';
+import { News, NewsSchema } from './schemas/news.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: News.name, schema: NewsSchema }]),
+  ],
+  controllers: [NewsController],
+  providers: [NewsService],
+})
+export class NewsModule {}

--- a/news-microservice/src/news/news.service.ts
+++ b/news-microservice/src/news/news.service.ts
@@ -1,0 +1,68 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { News } from './schemas/news.schema'; // Mongoose model class
+import { NewsEntity } from './entities/news.entity'; // Interface for type hints
+import { CreateNewsDto, UpdateNewsDto } from './dto/news.dto';
+
+@Injectable()
+export class NewsService {
+  constructor(@InjectModel(News.name) private newsModel: Model<News>) {}
+
+  async create(createNewsDto: CreateNewsDto): Promise<NewsEntity> {
+    const newNews = new this.newsModel(createNewsDto);
+    return newNews.save() as Promise<NewsEntity>;
+  }
+
+  async findAll(
+    category?: string,
+    isFeatured?: boolean,
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<{ data: NewsEntity[], total: number, page: number, limit: number }> {
+    const skip = (page - 1) * limit;
+    const queryConditions: any = {};
+
+    if (category) {
+      queryConditions.category = category;
+    }
+    if (isFeatured !== undefined) {
+      queryConditions.isFeatured = isFeatured;
+    }
+
+    const [data, total] = await Promise.all([
+      this.newsModel.find(queryConditions)
+        .sort({ publishedAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .exec() as Promise<NewsEntity[]>,
+      this.newsModel.countDocuments(queryConditions).exec(),
+    ]);
+
+    return { data, total, page, limit };
+  }
+
+  async findOne(id: string): Promise<NewsEntity> {
+    const newsItem = await this.newsModel.findById(id).exec();
+    if (!newsItem) {
+      throw new NotFoundException(`News with ID "${id}" not found`);
+    }
+    return newsItem as NewsEntity;
+  }
+
+  async update(id: string, updateNewsDto: UpdateNewsDto): Promise<NewsEntity> {
+    const updatedNews = await this.newsModel.findByIdAndUpdate(id, updateNewsDto, { new: true }).exec();
+    if (!updatedNews) {
+      throw new NotFoundException(`News with ID "${id}" not found`);
+    }
+    return updatedNews as NewsEntity;
+  }
+
+  async remove(id: string): Promise<NewsEntity> {
+    const deletedNews = await this.newsModel.findByIdAndDelete(id).exec();
+    if (!deletedNews) {
+      throw new NotFoundException(`News with ID "${id}" not found`);
+    }
+    return deletedNews as NewsEntity;
+  }
+}

--- a/news-microservice/src/news/schemas/news.schema.ts
+++ b/news-microservice/src/news/schemas/news.schema.ts
@@ -1,0 +1,40 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class News extends Document {
+  @Prop({ required: true, trim: true })
+  title: string;
+
+  @Prop({ required: true, trim: true })
+  excerpt: string;
+
+  @Prop({ required: true })
+  content: string;
+
+  @Prop()
+  imageUrl?: string;
+
+  @Prop({ required: true })
+  category: string;
+
+  @Prop([String])
+  tags?: string[];
+
+  @Prop()
+  author?: string;
+
+  @Prop()
+  sourceUrl?: string;
+
+  @Prop({ required: true })
+  publishedAt: Date;
+
+  @Prop({ default: false })
+  isFeatured?: boolean;
+
+  @Prop({ default: 0 })
+  views?: number;
+}
+
+export const NewsSchema = SchemaFactory.createForClass(News);

--- a/news-microservice/tsconfig.json
+++ b/news-microservice/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}

--- a/src/api/news/news.controller.ts
+++ b/src/api/news/news.controller.ts
@@ -6,11 +6,25 @@ import { NewsEntity } from '../../entities/news.entity';
 export class NewsController {
   constructor(private readonly newsService: NewsService) {}
 
+import { Types } from 'mongoose'; // Import Types
+
   private mapNewsEntityToDto(entity: NewsEntity): NewsItemDto {
+    // entity.id is a virtual getter from Mongoose that returns string version of _id
+    // Prefer entity.id as it's usually available and correctly typed.
+    // If _id must be accessed directly and its type is 'unknown' or 'any',
+    // casting might be needed for toString(), e.g., (entity._id as Types.ObjectId).toString()
+    // or (entity._id as any).toString().
+    // However, entity.id should be sufficient and safer.
+    const id = entity.id || (entity._id as Types.ObjectId)?.toString();
+    if (!id) {
+      // This case should ideally not happen for a saved Mongoose document
+      console.error('Error mapping NewsEntity: ID is missing.', entity);
+      throw new Error('Failed to map NewsEntity due to missing ID.');
+    }
     return {
-      id: entity.id || entity._id.toString(), // Mongoose documents have .id virtual or ._id
+      id: id,
       title: entity.title,
-      date: entity.publishedAt.toISOString(), // Or any other preferred string format
+      date: entity.publishedAt.toISOString(),
       category: entity.category,
       image: entity.imageUrl,
       excerpt: entity.excerpt,

--- a/src/api/news/news.controller.ts
+++ b/src/api/news/news.controller.ts
@@ -1,17 +1,52 @@
 import { Controller, Get, Post, Body, Param, Put, Delete, Query, NotFoundException } from '@nestjs/common';
-import { NewsService, CreateNewsDto, UpdateNewsDto } from './news.service';
+import { NewsService, CreateNewsDto, UpdateNewsDto, NewsPageDataDto, NewsItemDto } from './news.service';
 import { NewsEntity } from '../../entities/news.entity';
 
-@Controller('api/news') // Standardized API prefix
+@Controller('api/news') // Standardized API prefix for news-related endpoints
 export class NewsController {
   constructor(private readonly newsService: NewsService) {}
 
-  @Post()
+  private mapNewsEntityToDto(entity: NewsEntity): NewsItemDto {
+    return {
+      id: entity.id || entity._id.toString(), // Mongoose documents have .id virtual or ._id
+      title: entity.title,
+      date: entity.publishedAt.toISOString(), // Or any other preferred string format
+      category: entity.category,
+      image: entity.imageUrl,
+      excerpt: entity.excerpt,
+      views: entity.views,
+    };
+  }
+
+  @Get('page-data') // This will be accessible at GET /api/news/page-data
+  async getNewsPageData(): Promise<NewsPageDataDto> {
+    const newsEntities = await this.newsService.findAll();
+    const newsItems = newsEntities.map(entity => this.mapNewsEntityToDto(entity));
+
+    const recommendedTools = [
+      { id: 1, name: 'ChatGPT', description: '智能对话助手', icon: 'https://ext.same-assets.com/155488376/946268843.jpeg'},
+      { id: 2, name: 'Claude 4', description: '高级AI助手', icon: 'https://ext.same-assets.com/155488376/614836080.jpeg'},
+    ];
+    const popularTopics = [
+      { id: 'ai-ethics', name: 'AI Ethics' },
+      { id: 'generative-ai', name: 'Generative AI' },
+      { id: 'llms', name: 'Large Language Models' },
+    ];
+
+    return {
+      newsItems,
+      recommendedTools,
+      popularTopics,
+    };
+  }
+
+  // Existing CRUD operations for news articles
+  @Post() // Path becomes POST /api/news
   async create(@Body() createNewsDto: CreateNewsDto): Promise<NewsEntity> {
     return this.newsService.create(createNewsDto);
   }
 
-  @Get()
+  @Get() // Path becomes GET /api/news
   async findAll(
     @Query('category') category?: string,
     @Query('isFeatured') isFeatured?: string,

--- a/src/api/news/news.service.ts
+++ b/src/api/news/news.service.ts
@@ -20,6 +20,25 @@ export class CreateNewsDto {
 
 export class UpdateNewsDto extends CreateNewsDto {}
 
+// DTO for individual news items tailored for NewsPage.tsx
+export class NewsItemDto {
+  id: string; // MongoDB IDs are strings
+  title: string;
+  date: string; // Will be formatted string from Date
+  category?: string;
+  image?: string;
+  excerpt?: string;
+  views?: number; // Keep as number
+  // likes are not in NewsEntity, so not included unless we add them
+}
+
+// DTO for the /api/news-page-data endpoint response
+export class NewsPageDataDto {
+  newsItems: NewsItemDto[];
+  recommendedTools: { id: number; name: string; description: string; icon: string; }[];
+  popularTopics: { id: string; name: string; }[];
+}
+
 @Injectable()
 export class NewsService {
   constructor(@InjectModel(News.name) private newsModel: Model<News>) {}

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,17 +1,25 @@
-import { Controller, Get, Res, Req } from '@nestjs/common';
+import { Controller, Get, Res, Req, Next } from '@nestjs/common';
 import { AppService } from './app.service';
 import { join } from 'path';
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
-  // This will serve index.html for any route not caught by other controllers
-  // and not starting with /api (to protect API endpoints).
-  // It also avoids serving index.html for files with extensions (e.g. .css, .js, .png).
-  @Get(/^\/(?!api|.*\.(css|js|png|jpg|jpeg|gif|ico|json|map)$).*$/) // Regex to exclude /api and common static file extensions
-  serveReactApp(@Res() res: Response) {
-    res.sendFile(join(process.cwd(), 'dist', 'client', 'index.html'));
+  @Get('*') // Catch all GET requests
+  serveReactApp(@Req() req: Request, @Res() res: Response, @Next() next: NextFunction) {
+    const path = req.path;
+    const spaPathRegex = /^\/(?!api|.*\.(css|js|png|jpg|jpeg|gif|ico|json|map)$).*$/;
+
+    if (spaPathRegex.test(path)) {
+      // If it's an SPA route, serve index.html
+      res.sendFile(join(process.cwd(), 'dist', 'client', 'index.html'));
+    } else {
+      // Otherwise, let other handlers (like static file middleware or other controllers) take over
+      // If this is the absolute last route, NestJS will 404 if 'next()' doesn't find anything.
+      // This assumes static assets and API routes are already handled by their respective modules/middleware.
+      next();
+    }
   }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,13 +1,16 @@
-import { Controller, Get, Res } from '@nestjs/common';
+import { Controller, Get, Res, Req } from '@nestjs/common';
 import { AppService } from './app.service';
 import { join } from 'path';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
-  @Get('/')
+  // This will serve index.html for any route not caught by other controllers
+  // and not starting with /api (to protect API endpoints).
+  // It also avoids serving index.html for files with extensions (e.g. .css, .js, .png).
+  @Get(/^\/(?!api|.*\.(css|js|png|jpg|jpeg|gif|ico|json|map)$).*$/) // Regex to exclude /api and common static file extensions
   serveReactApp(@Res() res: Response) {
     res.sendFile(join(process.cwd(), 'dist', 'client', 'index.html'));
   }


### PR DESCRIPTION
- Implement /api/news/page-data endpoint in the monolith.
- Add SPA fallback support to the monolith for client-side routing.
- Develop a standalone News Microservice:
  - Basic NestJS project structure.
  - NewsModule with controller, service, entity, schema, DTOs.
  - API endpoints for /page-data and CRUD operations on /articles.
  - Mongoose database configuration.
- Update frontend NewsPage.tsx to use correct API endpoint and data types.